### PR TITLE
Migrate jira cloud provider to axios

### DIFF
--- a/doc/architecture-decisions/ADR-011.md
+++ b/doc/architecture-decisions/ADR-011.md
@@ -1,0 +1,19 @@
+# ADR 11: Axios for calls to the Jira API
+
+## Status
+
+accepted
+
+## Context
+
+We want to be able to configure the headers, base URL and other parameters once for Jira API calls, instead of each time we make a call as previous with the `fetch` and `cross-fetch` packages.
+
+## Decision
+
+We are now using [Axios](https://axios-http.com/docs/intro), a package that enables creation of REST clients and enables us to configure defaults for each call.
+Additionally, we are able to define error handlers for specific HTTP error calls, enabling default error handling for e.g. 401 responses.
+
+## Consequences
+
+Every call to the Jira Server API (except for authorization calls to e.g. fetch a token) should be made via an Axios instance.
+This also means rewriting the error handling in each call, finding common errors and enabling default handling for them.

--- a/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
+++ b/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
@@ -1081,9 +1081,11 @@ export class JiraCloudProvider implements IProvider {
   getResource(): Promise<Resource> {
     return new Promise<Resource>((resolve, reject) => {
       if (this.accessToken !== undefined) {
+        // IMPROVE expose API client instead of resource
+        const defaults = this.getRestApiClient(3).defaults
         const result: Resource = {
-          baseUrl: `https://api.atlassian.com/ex/jira/${this.cloudID}/rest/api/3/`,
-          authorization: `Bearer ${this.accessToken}`,
+          baseUrl: defaults.baseURL ?? '',
+          authorization: defaults.headers.Authorization as string,
         }
         resolve(result)
       } else {

--- a/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
+++ b/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
@@ -184,7 +184,7 @@ export class JiraCloudProvider implements IProvider {
   async getProjects(): Promise<Project[]> {
     return new Promise((resolve, reject) => {
       this.getRestApiClient(3)
-        .get('/project/searchs?expand=description,lead,issueTypes,url,projectKeys,permissions,insight')
+        .get('/project/search?expand=description,lead,issueTypes,url,projectKeys,permissions,insight')
         .then(async (response) => {
           const projects = response.data.values.map((project: JiraProject) => ({
             key: project.key,

--- a/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
+++ b/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
@@ -60,6 +60,8 @@ export class JiraCloudProvider implements IProvider {
             return Promise.reject(recreateAxiosError(error, `Invalid request: ${JSON.stringify(error.response.data)}`))
           } else if (statusCode === 401) {
             return Promise.reject(recreateAxiosError(error, `User not authenticated: ${JSON.stringify(error.response.data)}`))
+          } else if (error.response.status === 429) {
+            return Promise.reject(recreateAxiosError(error, `Rate limit exceeded: ${JSON.stringify(error.response.data)}`))
           }
         }
 
@@ -286,8 +288,6 @@ export class JiraCloudProvider implements IProvider {
           if (error.response) {
             if (error.response.status === 404) {
               specificError = new Error(`Project, issue, or transition were not found: ${error.response.data}`)
-            } else if (error.response.status === 429) {
-              specificError = new Error(`Rate limit exceeded: ${error.response.data}`)
             }
           }
 

--- a/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
+++ b/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../types/jira"
 import { IProvider } from "../base-provider"
 import { getAccessToken, refreshTokens } from "./getAccessToken"
+import { Axios } from "axios";
 
 export class JiraCloudProvider implements IProvider {
   public accessToken: string | undefined
@@ -30,6 +31,27 @@ export class JiraCloudProvider implements IProvider {
   private customFields = new Map<string, string>()
 
   private reversedCustomFields = new Map<string, string>()
+
+  private constructRestBasedClient(basePath: string, version: string) {
+    // TODO define validateStatus
+    // TODO catch errors and handle common status codes
+    return new Axios({
+      baseURL: `https://api.atlassian.com/ex/jira/${this.cloudID}/rest/${basePath}/${version}`,
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${this.accessToken}`,
+        "Content-Type": "application/json",
+      }
+    })
+  }
+
+  private getRestApiClient(version: number) {
+    return this.constructRestBasedClient('api', version.toString());
+  }
+
+  private getAgileRestApiClient(version: string) {
+    return this.constructRestBasedClient('agile', version);
+  }
 
   offsetDate(date: Date) {
     if (!date) {

--- a/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
+++ b/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
@@ -1,4 +1,5 @@
 /* eslint-disable class-methods-use-this */
+import axios, { AxiosError, AxiosResponse, isAxiosError } from "axios";
 import {
   dateTimeFormat,
   Issue,
@@ -19,8 +20,6 @@ import {
 } from "../../../types/jira"
 import { IProvider } from "../base-provider"
 import { getAccessToken, refreshTokens } from "./getAccessToken"
-import { AxiosError, AxiosResponse, isAxiosError } from "axios";
-import axios from "axios"
 
 export class JiraCloudProvider implements IProvider {
   public accessToken: string | undefined
@@ -58,11 +57,11 @@ export class JiraCloudProvider implements IProvider {
           const statusCode = error.response.status
           if (statusCode === 400) {
             return Promise.reject(recreateAxiosError(error, `Invalid request: ${JSON.stringify(error.response.data)}`))
-          } else if (statusCode === 401) {
+          } if (statusCode === 401) {
             return Promise.reject(recreateAxiosError(error, `User not authenticated: ${JSON.stringify(error.response.data)}`))
-          } else if (error.response.status === 403) {
+          } if (error.response.status === 403) {
             return Promise.reject(recreateAxiosError(error, `User does not have a valid licence: ${JSON.stringify(error.response.data)}`))
-          } else if (error.response.status === 429) {
+          } if (error.response.status === 429) {
             return Promise.reject(recreateAxiosError(error, `Rate limit exceeded: ${JSON.stringify(error.response.data)}`))
           }
         }
@@ -436,7 +435,7 @@ export class JiraCloudProvider implements IProvider {
 
   async fetchIssues(response: AxiosResponse): Promise<Issue[]> {
     const rankCustomField = this.customFields.get("Rank") || ""
-    return new Promise((resolve, _) => {
+    return new Promise((resolve) => {
       const issues: Promise<Issue[]> = Promise.all(
         response.data.issues.map(async (element: JiraIssue) => ({
           issueKey: element.key,
@@ -817,7 +816,7 @@ export class JiraCloudProvider implements IProvider {
       `/issue/${issueKey}/transitions`,
     )
 
-    const data = transitionResponse.data
+    const {data} = transitionResponse
 
     data.transitions.forEach((field: { name: string; id: string }) => {
       transitions.set(field.name, field.id)
@@ -1060,7 +1059,7 @@ export class JiraCloudProvider implements IProvider {
     return new Promise<Resource>((resolve, reject) => {
       if (this.accessToken !== undefined) {
         // IMPROVE expose API client instead of resource
-        const defaults = this.getRestApiClient(3).defaults
+        const {defaults} = this.getRestApiClient(3)
         const result: Resource = {
           baseUrl: defaults.baseURL ?? '',
           authorization: defaults.headers.Authorization as string,

--- a/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
+++ b/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
@@ -60,6 +60,8 @@ export class JiraCloudProvider implements IProvider {
             return Promise.reject(recreateAxiosError(error, `Invalid request: ${JSON.stringify(error.response.data)}`))
           } else if (statusCode === 401) {
             return Promise.reject(recreateAxiosError(error, `User not authenticated: ${JSON.stringify(error.response.data)}`))
+          } else if (error.response.status === 403) {
+            return Promise.reject(recreateAxiosError(error, `User does not have a valid licence: ${JSON.stringify(error.response.data)}`))
           } else if (error.response.status === 429) {
             return Promise.reject(recreateAxiosError(error, `Rate limit exceeded: ${JSON.stringify(error.response.data)}`))
           }
@@ -342,14 +344,7 @@ export class JiraCloudProvider implements IProvider {
           resolve(boardIds)
         })
         .catch((error) => {
-          let specificError = error
-          if (error.response) {
-            if (error.response.status === 403) {
-              specificError = new Error(`User does not have a valid licence: ${error.response.data}`)
-            }
-          }
-
-          reject(new Error(`Error getting projects: ${specificError}`))
+          reject(new Error(`Error getting projects: ${error}`))
         })
     })
   }
@@ -385,9 +380,7 @@ export class JiraCloudProvider implements IProvider {
         .catch((error) => {
           let specificError = error
           if (error.response) {
-            if (error.response.status === 403) {
-              specificError = new Error(`User does not have a valid licence: ${error.response.data}`)
-            } else if (error.response.status === 404) {
+            if (error.response.status === 404) {
               specificError = new Error(
                 `The board does not exist or the user does not have permission to view it: ${error.response.data}`
               )
@@ -478,9 +471,7 @@ export class JiraCloudProvider implements IProvider {
       return error;
     }
 
-    if (error.response.status === 403) {
-      return new Error(`User does not have a valid licence: ${error.response.data}`)
-    } else if (error.response.status === 404) {
+    if (error.response.status === 404) {
       return new Error(
         `The board does not exist or the user does not have permission to view it: ${error.response.data}`
       )
@@ -808,11 +799,7 @@ export class JiraCloudProvider implements IProvider {
         .catch((error) => {
           let specificError = error
           if (error.response) {
-            if (error.response.status === 403) {
-              specificError = new Error(
-                "The user does not have the necessary permissions"
-              )
-            } else if (error.response.status === 404) {
+            if (error.response.status === 404) {
               specificError = new Error(
                 "The issue was not found or the user does not have the necessary permissions"
               )
@@ -864,9 +851,7 @@ export class JiraCloudProvider implements IProvider {
         .catch((error) => {
           let specificError = error
           if (error.response) {
-            if (error.response.status === 403) {
-              specificError = new Error(`User does not have a valid licence: ${error.response.data}`)
-            } else if (error.response.status === 404) {
+            if (error.response.status === 404) {
               specificError = new Error(
                 `The board does not exist or the user does not have permission to view it: ${error.response.data}`
               )
@@ -1066,14 +1051,7 @@ export class JiraCloudProvider implements IProvider {
           resolve(createdSubtask)
         })
         .catch((error) => {
-          let specificError = error
-          if (error.response) {
-            if (error.response.status === 403) {
-              specificError = new Error(`User does not have a valid licence: ${error.response.data}`)
-            }
-          }
-
-          reject(new Error(`Error creating subtask: ${specificError}`))
+          reject(new Error(`Error creating subtask: ${error}`))
         })
     })
   }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@tanstack/react-query-devtools": "^4.23.0",
     "@types/file-saver": "^2.0.5",
     "@types/react-beautiful-dnd": "^13.1.3",
+    "axios": "^1.6.1",
     "cross-fetch": "^3.1.5",
     "dayjs": "^1.11.7",
     "dotenv": "^16.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,6 +2416,15 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.2.tgz#2f6f3cde40935825cf4465e3c1c9e77b240ff6ae"
   integrity sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==
 
+axios@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.1.tgz#76550d644bf0a2d469a01f9244db6753208397d7"
+  integrity sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^3.1.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.2.1.tgz#39c378a6e3b06ca679f29138151e45b2b32da62a"
@@ -4274,6 +4283,11 @@ flora-colossus@^2.0.0:
   dependencies:
     debug "^4.3.4"
     fs-extra "^10.1.0"
+
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -6891,6 +6905,11 @@ proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
Migrates the Jira Cloud provider to the axios request library to significantly reduce code duplication and room for error. Unified handling of the APIs is paramount to fast extensibility.