### PR TITLE
Fix reloading sprints after creating a sprint

### DIFF
--- a/src/components/BacklogView/CreateSprint/CreateSprintModal.tsx
+++ b/src/components/BacklogView/CreateSprint/CreateSprintModal.tsx
@@ -55,6 +55,7 @@ export function CreateSprintModal({
         message: `The sprint has been created!`,
         color: "green",
       })
+      queryClient.invalidateQueries({ queryKey: ["sprints"] })
       queryClient.invalidateQueries({ queryKey: ["issues", "sprints"] })
       setOpened(false)
       form.reset()


### PR DESCRIPTION
Sprint list is now reloaded after creating a sprint.

* Fixes https://projectcanvas.atlassian.net/browse/SCRUM-50