### PR TITLE
Upgrade tabler icons library to new react package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@mantine/form": "^7.0.0",
     "@mantine/hooks": "^7.0.0",
     "@mantine/notifications": "^7.0.0",
-    "@tabler/icons": "^1.116.1",
+    "@tabler/icons-react": "^2.44.0",
     "@tanstack/react-query": "^4.23.0",
     "@tanstack/react-query-devtools": "^4.23.0",
     "@types/file-saver": "^2.0.5",

--- a/src/components/BacklogView/BacklogView.tsx
+++ b/src/components/BacklogView/BacklogView.tsx
@@ -12,7 +12,7 @@ import {
   TextInput,
   Title,
 } from "@mantine/core"
-import { IconSearch } from "@tabler/icons"
+import { IconSearch } from "@tabler/icons-react"
 import { useQueries, useQuery } from "@tanstack/react-query"
 import { ChangeEvent, useEffect, useState } from "react"
 import { DragDropContext } from "@hello-pangea/dnd"

--- a/src/components/BacklogView/Issue/DeleteButton.tsx
+++ b/src/components/BacklogView/Issue/DeleteButton.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Transition, Popover, Box } from "@mantine/core"
-import { IconTrash } from "@tabler/icons"
+import { IconTrash } from "@tabler/icons-react"
 import { useEffect, useState } from "react"
 import { useHover } from "@mantine/hooks";
 import { DeleteIssueAlert } from "../../DetailView/Components/DeleteIssue/DeleteIssueAlert"

--- a/src/components/BacklogView/Issue/IssueIcon.tsx
+++ b/src/components/BacklogView/Issue/IssueIcon.tsx
@@ -5,7 +5,7 @@ import {
   IconBug,
   IconBolt,
   IconEdit,
-} from "@tabler/icons"
+} from "@tabler/icons-react"
 import { ReactElement } from "react";
 
 export function IssueIcon({ type }: { type: string }) {

--- a/src/components/BacklogView/IssuesWrapper/SprintsPanel.tsx
+++ b/src/components/BacklogView/IssuesWrapper/SprintsPanel.tsx
@@ -1,5 +1,5 @@
 import { Accordion, Badge, Flex, Group, Text, Title } from "@mantine/core"
-import { IconChevronRight } from "@tabler/icons"
+import { IconChevronRight } from "@tabler/icons-react"
 import { Issue, Sprint } from "types"
 import {
   pluralize,

--- a/src/components/BacklogView/ReloadButton.tsx
+++ b/src/components/BacklogView/ReloadButton.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon } from "@mantine/core"
-import { IconReload } from "@tabler/icons"
+import { IconReload } from "@tabler/icons-react"
 import { useQueryClient } from "@tanstack/react-query"
 
 export function ReloadButton({ ...props }) {

--- a/src/components/CreateIssue/Fields/AttachmentFileInput.tsx
+++ b/src/components/CreateIssue/Fields/AttachmentFileInput.tsx
@@ -1,6 +1,6 @@
 import { FileInput, Text } from "@mantine/core"
 import { UseFormReturnType } from "@mantine/form"
-import { IconFileUpload } from "@tabler/icons"
+import { IconFileUpload } from "@tabler/icons-react"
 import { Issue } from "types"
 
 export function AttachmentFileInput({

--- a/src/components/DetailView/Components/AddSubtask/AddSubtask.tsx
+++ b/src/components/DetailView/Components/AddSubtask/AddSubtask.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Group, Loader, TextInput } from "@mantine/core"
 import { showNotification } from "@mantine/notifications"
-import { IconPlus } from "@tabler/icons"
+import { IconPlus } from "@tabler/icons-react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { createSubtaskMutation } from "./queries"

--- a/src/components/DetailView/Components/Attachments/Attachments.tsx
+++ b/src/components/DetailView/Components/Attachments/Attachments.tsx
@@ -14,7 +14,7 @@ import {
   Center,
   LoadingOverlay,
 } from "@mantine/core"
-import { IconCloudDownload, IconPlus, IconTrash } from "@tabler/icons"
+import { IconCloudDownload, IconPlus, IconTrash } from "@tabler/icons-react"
 import { showNotification } from "@mantine/notifications"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import FileSaver from "file-saver"

--- a/src/components/DetailView/Components/DeleteIssue/DeleteIssue.tsx
+++ b/src/components/DetailView/Components/DeleteIssue/DeleteIssue.tsx
@@ -1,5 +1,5 @@
 import { Button, Popover } from "@mantine/core"
-import { IconTrash } from "@tabler/icons"
+import { IconTrash } from "@tabler/icons-react"
 import { useState } from "react";
 import { DeleteIssueAlert } from "./DeleteIssueAlert"
 import { useColorScheme } from "../../../../common/color-scheme";

--- a/src/components/DetailView/Components/DeleteIssue/DeleteIssueAlert.tsx
+++ b/src/components/DetailView/Components/DeleteIssue/DeleteIssueAlert.tsx
@@ -1,5 +1,5 @@
 import { Button, Stack, Alert } from "@mantine/core"
-import { IconAlertCircle } from "@tabler/icons"
+import { IconAlertCircle } from "@tabler/icons-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { deleteIssueMutation } from "./queries"
 

--- a/src/components/DetailView/Components/IssueStatusMenu.tsx
+++ b/src/components/DetailView/Components/IssueStatusMenu.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Menu } from "@mantine/core"
 import { useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { IconCaretDown } from "@tabler/icons";
+import { IconCaretDown } from "@tabler/icons-react";
 import { getIssueTypes, setStatus } from "../../CreateIssue/queryFunctions";
 import classes from "./IssueStatusMenu.module.css";
 

--- a/src/components/DetailView/Components/SubTask/Subtask.tsx
+++ b/src/components/DetailView/Components/SubTask/Subtask.tsx
@@ -1,5 +1,5 @@
 import { Box, Group, Loader, Text, ThemeIcon } from "@mantine/core"
-import { IconBinaryTree2, IconTrash } from "@tabler/icons"
+import { IconBinaryTree2, IconTrash } from "@tabler/icons-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { IssueSummary } from "../IssueSummary"
 import { deleteSubtaskMutation } from "./queries"

--- a/src/components/EpicDetailView/Components/SubTask/Subtask.tsx
+++ b/src/components/EpicDetailView/Components/SubTask/Subtask.tsx
@@ -1,5 +1,5 @@
 import { Box, Group, Loader, Text, ThemeIcon } from "@mantine/core"
-import { IconBinaryTree2, IconTrash } from "@tabler/icons"
+import { IconBinaryTree2, IconTrash } from "@tabler/icons-react"
 import { useQueryClient } from "@tanstack/react-query"
 import { IssueSummary } from "../IssueSummary"
 import { deleteSubtaskMutation } from "./queries"

--- a/src/components/EpicView/EpicCard.tsx
+++ b/src/components/EpicView/EpicCard.tsx
@@ -15,7 +15,7 @@ import {
 import {useHover} from "@mantine/hooks";
 import {useState} from "react";
 import {useQueryClient} from "@tanstack/react-query";
-import {IconBolt} from "@tabler/icons";
+import {IconBolt} from "@tabler/icons-react";
 import {DeleteButton} from "../BacklogView/Issue/DeleteButton";
 import {EpicDetailView} from "../EpicDetailView/EpicDetailView";
 import {StatusType} from "../../../types/status";

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,5 +1,5 @@
 import {Button, Container, Divider, Group, Image, Paper, rgba} from "@mantine/core"
-import { IconCloud, IconServer } from "@tabler/icons"
+import { IconCloud, IconServer } from "@tabler/icons-react"
 import { ipcRenderer } from "electron"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"

--- a/src/components/ProjectsView/Table/ProjectsTable.tsx
+++ b/src/components/ProjectsView/Table/ProjectsTable.tsx
@@ -1,7 +1,13 @@
 import { ScrollArea, Table, Text, TextInput, Center, Group, UnstyledButton } from "@mantine/core"
-import { IconChevronDown, IconChevronUp, IconSearch, IconSelector, TablerIcon } from "@tabler/icons-react"
+import {
+  IconChevronDown,
+  IconChevronUp,
+  IconSearch,
+  IconSelector,
+  TablerIconsProps
+} from "@tabler/icons-react"
 import { Project } from "types"
-import { useEffect, useState, ChangeEvent } from "react"
+import { JSX, useEffect, useState, ChangeEvent } from "react"
 import { useNavigate } from "react-router-dom"
 import { useCanvasStore } from "../../../lib/Store"
 import { sortData } from "./TableHelper"
@@ -46,7 +52,7 @@ export function ProjectsTable({ data }: { data: Project[] }) {
   }
 
   const header = data && data.length > 0 && Object.keys(data[0]).map((key) => {
-    let Icon: TablerIcon
+    let Icon: (props: TablerIconsProps) => JSX.Element
     if (sortBy === key) {
       if (reverseSortDirection) Icon = IconChevronUp
       else Icon = IconChevronDown

--- a/src/components/ProjectsView/Table/ProjectsTable.tsx
+++ b/src/components/ProjectsView/Table/ProjectsTable.tsx
@@ -1,5 +1,5 @@
 import { ScrollArea, Table, Text, TextInput, Center, Group, UnstyledButton } from "@mantine/core"
-import { IconChevronDown, IconChevronUp, IconSearch, IconSelector, TablerIcon } from "@tabler/icons"
+import { IconChevronDown, IconChevronUp, IconSearch, IconSelector, TablerIcon } from "@tabler/icons-react"
 import { Project } from "types"
 import { useEffect, useState, ChangeEvent } from "react"
 import { useNavigate } from "react-router-dom"

--- a/src/components/ProjectsView/Table/ProjectsTable.tsx
+++ b/src/components/ProjectsView/Table/ProjectsTable.tsx
@@ -1,13 +1,13 @@
 import { ScrollArea, Table, Text, TextInput, Center, Group, UnstyledButton } from "@mantine/core"
 import {
+  Icon,
   IconChevronDown,
   IconChevronUp,
   IconSearch,
   IconSelector,
-  TablerIconsProps
 } from "@tabler/icons-react"
 import { Project } from "types"
-import { JSX, useEffect, useState, ChangeEvent } from "react"
+import { useEffect, useState, ChangeEvent } from "react"
 import { useNavigate } from "react-router-dom"
 import { useCanvasStore } from "../../../lib/Store"
 import { sortData } from "./TableHelper"
@@ -52,11 +52,11 @@ export function ProjectsTable({ data }: { data: Project[] }) {
   }
 
   const header = data && data.length > 0 && Object.keys(data[0]).map((key) => {
-    let Icon: (props: TablerIconsProps) => JSX.Element
+    let SortIcon: Icon
     if (sortBy === key) {
-      if (reverseSortDirection) Icon = IconChevronUp
-      else Icon = IconChevronDown
-    } else Icon = IconSelector
+      if (reverseSortDirection) SortIcon = IconChevronUp
+      else SortIcon = IconChevronDown
+    } else SortIcon = IconSelector
 
     return (
         <Table.Th key={key}>
@@ -66,7 +66,7 @@ export function ProjectsTable({ data }: { data: Project[] }) {
                 {key.toLocaleUpperCase()}
               </Text>
               <Center className={classes.headerSortIcon}>
-                <Icon size={14} stroke={1.5} />
+                <SortIcon size={14} stroke={1.5} />
               </Center>
             </Group>
           </UnstyledButton>

--- a/src/components/StoryMapView/Cards/Add/AddCard.tsx
+++ b/src/components/StoryMapView/Cards/Add/AddCard.tsx
@@ -1,5 +1,5 @@
 import { PaperProps } from "@mantine/core"
-import { IconPlus } from "@tabler/icons"
+import { IconPlus } from "@tabler/icons-react"
 import { MouseEventHandler } from "react"
 import { Draggable } from "@hello-pangea/dnd"
 import { BaseCard } from "../Base/BaseCard"

--- a/src/components/StoryMapView/Cards/Add/AddCase.tsx
+++ b/src/components/StoryMapView/Cards/Add/AddCase.tsx
@@ -1,4 +1,4 @@
-import { IconPlus } from "@tabler/icons"
+import { IconPlus } from "@tabler/icons-react"
 import { MouseEventHandler } from "react"
 import { BaseCard } from "../Base/BaseCard"
 

--- a/src/components/StoryMapView/Components/DeleteButton.tsx
+++ b/src/components/StoryMapView/Components/DeleteButton.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Transition } from "@mantine/core"
-import { IconTrash } from "@tabler/icons"
+import { IconTrash } from "@tabler/icons-react"
 import { MouseEventHandler } from "react"
 
 export function DeleteButton({

--- a/src/components/StoryMapView/Components/Zoom.tsx
+++ b/src/components/StoryMapView/Components/Zoom.tsx
@@ -1,5 +1,5 @@
 import { Affix, Group, ActionIcon, Text } from "@mantine/core"
-import { IconMinus, IconPlus } from "@tabler/icons"
+import { IconMinus, IconPlus } from "@tabler/icons-react"
 
 export function Zoom({
   setZoomValue,

--- a/src/components/StoryMapView/Level/AddLevel.tsx
+++ b/src/components/StoryMapView/Level/AddLevel.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@mantine/core"
-import { IconPlus } from "@tabler/icons"
+import { IconPlus } from "@tabler/icons-react"
 import { getRndInteger, LEVEL_PREFIX } from "../helpers/utils"
 import { useStoryMapStore } from "../StoryMapStore"
 

--- a/src/components/StoryMapView/Level/LevelControl.tsx
+++ b/src/components/StoryMapView/Level/LevelControl.tsx
@@ -1,5 +1,5 @@
 import {Accordion, AccordionControlProps, ActionIcon, Center, TextInput} from "@mantine/core"
-import { IconTrash } from "@tabler/icons"
+import { IconTrash } from "@tabler/icons-react"
 import { useState } from "react"
 import { useStoryMapStore } from "../StoryMapStore"
 import { SubActionLevel } from "../Types"

--- a/src/components/StoryMapView/StoryMap/AddStoryMapCard.tsx
+++ b/src/components/StoryMapView/StoryMap/AddStoryMapCard.tsx
@@ -1,4 +1,4 @@
-import { IconPlus } from "@tabler/icons"
+import { IconPlus } from "@tabler/icons-react"
 import { BaseCard } from "../Cards/Base/BaseCard"
 import { getRndInteger, STORY_MAP_PREFIX } from "../helpers/utils"
 import { useStoryMapStore } from "../StoryMapStore"

--- a/src/components/common/ColorSchemeToggle.tsx
+++ b/src/components/common/ColorSchemeToggle.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, useMantineColorScheme } from "@mantine/core"
-import { IconSun, IconMoonStars } from "@tabler/icons"
+import { IconSun, IconMoonStars } from "@tabler/icons-react"
 
 export function ColorSchemeToggle({ ...props }) {
   const { colorScheme, toggleColorScheme } = useMantineColorScheme()

--- a/src/components/common/UserSelect/UserSelectMenu.tsx
+++ b/src/components/common/UserSelect/UserSelectMenu.tsx
@@ -6,7 +6,7 @@ import {
   UnstyledButton,
   ScrollArea,
 } from "@mantine/core"
-import { IconChevronDown } from "@tabler/icons"
+import { IconChevronDown } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 import { User } from "../../../../types"

--- a/src/components/layout/StoryMapMenu.tsx
+++ b/src/components/layout/StoryMapMenu.tsx
@@ -4,7 +4,7 @@ import {
   IconLayoutDashboard,
   IconMap,
   IconTrash,
-} from "@tabler/icons"
+} from "@tabler/icons-react"
 import { useNavigate } from "react-router-dom"
 import { useStoryMapStore } from "../StoryMapView/StoryMapStore"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,10 +1485,18 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tabler/icons@^1.116.1":
-  version "1.119.0"
-  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-1.119.0.tgz#8c590bc5a563c8673a78ccd451bedabd584b376e"
-  integrity sha512-Fk3Qq4w2SXcTjc/n1cuL5bccPkylrOMo7cYpQIf/yw6zP76LQV9dtLcHQUjFiUnaYuswR645CnURIhlafyAh9g==
+"@tabler/icons-react@^2.44.0":
+  version "2.44.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons-react/-/icons-react-2.44.0.tgz#8119d3b6321ebaf98400fba7932e280d008125f8"
+  integrity sha512-10qwrqJ/QBNgY4YYer9PjWmCwm3wv9aVK8kGAkFKkwu6UJURVLZ2ea+oFh5j6vSXnA1zMtUG+X8anR5fZ67Isw==
+  dependencies:
+    "@tabler/icons" "2.44.0"
+    prop-types "^15.7.2"
+
+"@tabler/icons@2.44.0":
+  version "2.44.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-2.44.0.tgz#9f3cf86150b23e84a6eaf9d29ab2b2aaa8c7eed6"
+  integrity sha512-WPPtihDcAwEm1QZM9MXQw6+r/R2/qx7KMU1eegsi9DsqBLAb0W2kbt6e/syvd6j9c+6XNpRVBW1ziGqSWQAWOg==
 
 "@tanstack/match-sorter-utils@^8.7.0":
   version "8.8.4"


### PR DESCRIPTION
They swapped it out for a new library. Doing the (trivial) migration in a new PR instead of #95.