### PR TITLE
Add disable windows defender step to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,28 @@ jobs:
           node-version: ${{ matrix.node_version }}
           cache: "yarn"
 
+      - name: Deactivate Windows Defender
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          export NODEPATH=$(where.exe node.exe)
+          export PROJECTDIR=$(pwd)
+          export YARNCACHE=$(yarn cache dir)
+          export TEMPDIR=$LOCALAPPDATA\\Temp
+          
+          powershell Add-MpPreference -ExclusionProcess ${NODEPATH}
+          powershell Add-MpPreference -ExclusionPath ${YARNCACHE}
+          powershell Add-MpPreference -ExclusionPath ${PROJECTDIR}
+          powershell Add-MpPreference -ExclusionPath ${TEMPDIR}
+          
+          echo "DisableArchiveScanning..."
+          powershell Start-Process -PassThru -Wait PowerShell -ArgumentList "'-Command Set-MpPreference -DisableArchiveScanning \$true'"
+          
+          echo "DisableBehaviorMonitoring..."
+          powershell Start-Process -PassThru -Wait PowerShell -ArgumentList "'-Command Set-MpPreference -DisableBehaviorMonitoring \$true'"
+          
+          echo "DisableRealtimeMonitoring..."
+          powershell Start-Process -PassThru -Wait PowerShell -ArgumentList "'-Command Set-MpPreference -DisableRealtimeMonitoring \$true'"
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Deactivate Windows Defender
         if: ${{ matrix.os == 'windows-latest' }}
+        shell: powershell
         run: |
           export NODEPATH=$(where.exe node.exe)
           export PROJECTDIR=$(pwd)


### PR DESCRIPTION
Windows Defender seems to slow down our yarn install and builds on Windows machines by a large amount. This PR aims to deactivate WD real time monitoring for some critical directories.