### PR TITLE
Revamp core calculations in issue export

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "axios": "^1.6.1",
     "cross-fetch": "^4.0.0",
     "dayjs": "^1.11.7",
+    "dayjs-business-days2": "^1.2.2",
     "dotenv": "^16.0.3",
     "electron-fetch": "^1.9.1",
     "electron-squirrel-startup": "^1.0.0",

--- a/src/components/CreateExport/CreateExportModal.tsx
+++ b/src/components/CreateExport/CreateExportModal.tsx
@@ -7,7 +7,7 @@ import { DateInput } from "@mantine/dates";
 import dayjs from "dayjs";
 import { useCanvasStore } from "../../lib/Store";
 import { Issue } from "../../../types";
-import { exportIssues } from "./exportHelper";
+import { addExportedTimeProperties, ExportableIssue, exportIssues } from "./exportHelper";
 import { getIssuesByProject } from "../BacklogView/helpers/queryFetchers";
 import { StatusType } from "../../../types/status";
 import { CheckboxStack } from "./CheckboxStack";
@@ -37,24 +37,31 @@ export function CreateExportModal({
 
   const [includedIssueTypes, setIncludedIssueTypes] = useState<string[]>([]);
   const [includedIssueStatus, setIncludedIssueStatus] = useState<string[]>([]);
-  const [issuesToExport, setIssuesToExport] = useState<Issue[]>([]);
+  const [issuesToExport, setIssuesToExport] = useState<ExportableIssue[]>([]);
   const [startDate, setStartDate] = useState<Date | null>(null);
   const [endDate, setEndDate] = useState<Date | null>(null);
 
   function calculateIssuesToExport() {
+    if (!startDate || !endDate) {
+      setIssuesToExport([]);
+    }
+
+    const inProgressStatusNames = issueStatus
+      .filter((status) => status.statusCategory.name === StatusType.IN_PROGRESS)
+      .map((status) => status.name);
+    const doneStatusNames = issueStatus
+      .filter((status) => status.statusCategory.name === StatusType.DONE)
+      .map((status) => status.name);
+
     setIssuesToExport(
       sortBy(
         issues
           .filter((issue) => includedIssueTypes.includes(issue.type))
-          .filter(
-            (issue) => includedIssueStatus.includes(issue.status),
-          )
-          .filter(
-            (issue) => !startDate || dayjs(startDate).isBefore(dayjs(issue.created)),
-          )
-          .filter(
-            (issue) => !endDate || dayjs(endDate).isAfter(dayjs(issue.created)),
-          ),
+          .filter((issue) => includedIssueStatus.includes(issue.status))
+          .map((issue) => addExportedTimeProperties(issue, inProgressStatusNames, doneStatusNames))
+          .filter((issue) => issue !== undefined)
+          .filter((issue) => dayjs(startDate).isBefore(issue!.startDate))
+          .filter((issue) => dayjs(endDate).isAfter(issue!.endDate)) as ExportableIssue[],
         ["issueKey"],
       ),
     );
@@ -164,12 +171,7 @@ export function CreateExportModal({
           <Button
             ml="auto"
             size="sm"
-            onClick={() => {
-              exportIssues(
-                issuesToExport,
-                issueStatus.filter((s) => includedIssueStatus.includes(s.name)),
-              );
-            }}
+            onClick={() => exportIssues(issuesToExport)}
           >
             Export CSV
           </Button>

--- a/src/components/CreateExport/CreateExportModal.tsx
+++ b/src/components/CreateExport/CreateExportModal.tsx
@@ -26,6 +26,7 @@ export function CreateExportModal({
     issueStatus,
   } = useCanvasStore();
   const boardId = useCanvasStore((state) => state.selectedProjectBoardIds)[0];
+  const doneIssueStatus = issueStatus.filter((status) => issueStatusByCategory[StatusType.DONE]?.includes(status));
 
   const { data: issues } = useQuery<unknown, unknown, Issue[]>({
     queryKey: ["issues", project?.key],
@@ -33,8 +34,6 @@ export function CreateExportModal({
     enabled: !!project?.key,
     initialData: [],
   });
-
-  const doneStatusNames = issueStatusByCategory[StatusType.DONE]?.map((s) => s.name) ?? [];
 
   const [includedIssueTypes, setIncludedIssueTypes] = useState<string[]>([]);
   const [includedIssueStatus, setIncludedIssueStatus] = useState<string[]>([]);
@@ -48,8 +47,7 @@ export function CreateExportModal({
         issues
           .filter((issue) => includedIssueTypes.includes(issue.type))
           .filter(
-            (issue) => includedIssueStatus.includes(issue.status)
-              && doneStatusNames.includes(issue.status),
+            (issue) => includedIssueStatus.includes(issue.status),
           )
           .filter(
             (issue) => !startDate || dayjs(startDate).isBefore(dayjs(issue.created)),
@@ -126,9 +124,9 @@ export function CreateExportModal({
               <Text size="md" fw={450} mt="7%" mb="10%">
                 Include Issue Status
               </Text>
-              {issueStatus && (
+              {doneIssueStatus && (
                 <CheckboxStack
-                  data={issueStatus.map((status) => ({
+                  data={doneIssueStatus.map((status) => ({
                     value: status.name,
                     label: status.name,
                   }))}

--- a/src/components/CreateExport/CreateExportModal.tsx
+++ b/src/components/CreateExport/CreateExportModal.tsx
@@ -143,7 +143,7 @@ export function CreateExportModal({
             </Stack>
             <Stack align="center" mt="xs" w="40%">
               <Text size="md" fw={450}>
-                Creation date range
+                In progress date range
               </Text>
               <DateInput
                 label="Start Date"

--- a/src/components/CreateExport/exportHelper.ts
+++ b/src/components/CreateExport/exportHelper.ts
@@ -1,20 +1,20 @@
 import { ipcRenderer } from "electron";
 import { showNotification } from "@mantine/notifications";
 import dayjs, { Dayjs } from "dayjs";
-import { ChangelogHistoryItem, Issue, IssueStatus } from "../../../types";
+import { ChangelogHistoryItem, Issue } from "../../../types";
 import { ExportReply, ExportStatus } from "../../../electron/export-issues";
-import { StatusType } from "../../../types/status";
 
-type ExportableIssue = Omit<Issue, "startDate"> & {
-  startDate?: Dayjs,
-  endDate?: Dayjs,
+export type ExportableIssue = Omit<Issue, "startDate"> & {
+  startDate: Dayjs,
+  endDate: Dayjs,
   workingDays: number,
 };
 
-const addExportedTimeProperties = (
+export const addExportedTimeProperties = (
   issue: Issue,
   inProgressStatusNames: string[],
-): ExportableIssue => {
+  doneStatusNames: string[],
+): ExportableIssue | undefined => {
   const statusItems = issue.changelog.histories
     .reverse()
     .map((history) => {
@@ -39,69 +39,35 @@ const addExportedTimeProperties = (
     (item) => item.fromString
       && inProgressStatusNames.includes(item.fromString)
       && item.toString
-      && !inProgressStatusNames.includes(item.toString),
+      && doneStatusNames.includes(item.toString),
   );
-  if (enterEdges.length !== leaveEdges.length) {
-    throw new Error(
-      `Inconsistent in-progress changelog history encountered. Enter edge count: ${enterEdges.length}. Leave edge count: ${leaveEdges.length}`,
-    );
-  }
 
   if (enterEdges.length === 0) {
-    return {
-      ...issue,
-      startDate: undefined,
-      endDate: undefined,
-      workingDays: 0,
-    };
+    return undefined;
   }
 
-  let workingDays = 0;
-  for (let i = 0; i < enterEdges.length; i += 1) {
-    const enterDate = dayjs(enterEdges[i].date);
-    const leaveDate = dayjs(leaveEdges[i].date);
-
-    workingDays += Math.ceil(leaveDate.diff(enterDate, "day", true));
-  }
+  const startDate = dayjs(enterEdges[0].date);
+  const endDate = dayjs(leaveEdges[leaveEdges.length - 1].date);
 
   return {
     ...issue,
-    startDate: dayjs(enterEdges[0].date),
-    endDate: dayjs(leaveEdges[leaveEdges.length - 1].date),
-    workingDays,
+    startDate,
+    endDate,
+    workingDays: Math.ceil(endDate.diff(startDate, "day", true)),
   };
 };
 
-export const exportIssues = (
-  issues: Issue[],
-  includedStatus: IssueStatus[],
-) => {
+export const exportIssues = (issues: ExportableIssue[]) => {
   const header = ["ID", "Name", "Start Date", "End Date", "Working days"];
   const data = [header.map((h) => `"${h}"`).join(",")];
 
-  const inProgressStatusNames = includedStatus
-    .filter((status) => status.statusCategory.name === StatusType.IN_PROGRESS)
-    .map((status) => status.name);
-
   issues.forEach((issue) => {
-    const exportableIssue = addExportedTimeProperties(
-      issue,
-      inProgressStatusNames,
-    );
     const exportedValues = [
-      `"${exportableIssue.issueKey}"`,
-      `"${exportableIssue.summary}"`,
-      `${
-        exportableIssue.startDate
-          ? `"${exportableIssue.startDate?.toISOString()}"`
-          : ""
-      }`,
-      `${
-        exportableIssue.endDate
-          ? `"${exportableIssue.endDate?.toISOString()}"`
-          : ""
-      }`,
-      exportableIssue.workingDays,
+      `"${issue.issueKey}"`,
+      `"${issue.summary}"`,
+      `"${issue.startDate?.toISOString()}"`,
+      `"${issue.endDate?.toISOString()}"`,
+      issue.workingDays,
     ];
 
     data.push(exportedValues.join(","));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3234,7 +3234,14 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-dayjs@^1.11.7:
+dayjs-business-days2@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/dayjs-business-days2/-/dayjs-business-days2-1.2.2.tgz#eb3739ec011ca9d292f7e28caef0fa552735d0d3"
+  integrity sha512-tYwNKeMxuNEpGw2k5j/KTcH0c1lV+41wfqkTN21OvP2hwZFnpM4dH2biaOI2gElRmJOQQxkKByuH5bZPlea/Jg==
+  dependencies:
+    dayjs "^1.11.10"
+
+dayjs@^1.11.10, dayjs@^1.11.7:
   version "1.11.10"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
   integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==


### PR DESCRIPTION
Changes some core behaviour in the issue export, namely:

- Changes the working days calculation to just be a diff from the start and end date
- Excludes weekends from this diff
- Precomputes the start and end dates and changes the date filter to only include issues if their first in-progress transition is after the start date and their last done-transition is before the end-date.
- Only shows "done" status for selection on what to include in the export

Open questions:
- ~What should happen with issues that never had a in-progress transition? Currently they are filtered out.~ -> Filtered out is fine.

* Closes: https://projectcanvas.atlassian.net/browse/SCRUM-104