### PR TITLE
Remove automatic run from the release CI and leave it to workflow dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,11 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    tags:
-      - "**"
 
 permissions:
   contents: write


### PR DESCRIPTION
We do not want the release CI to run every time we push something on main. This PR just removes the triggers to run the CI on the main branch and instead just leaves the "workflow_dispatch" option, so you manually dispatch the action to release the version you want to release.