### PR TITLE
Fix description for non-agile fetches in the cloud provider

### DIFF
--- a/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
+++ b/electron/providers/jira-cloud-provider/JiraCloudProvider.ts
@@ -524,7 +524,7 @@ export class JiraCloudProvider implements IProvider {
           // IMPROVE: Remove boolean flag
           description: isAgile
             ? element.fields.description
-            : element.fields.description?.content,
+            : element.fields.description?.content[0]?.content[0]?.text,
           subtasks: element.fields.subtasks,
           created: element.fields.created,
           updated: element.fields.updated,


### PR DESCRIPTION
The issue did not (as initially assumed) lie in the custom status, but was rather just a description set on this issue in Jira which could not be handled in the atlassian document format (ADF).

* Fixes https://projectcanvas.atlassian.net/browse/SCRUM-112