### PR TITLE
Fix navigation upon deleting all story maps

### DIFF
--- a/src/components/layout/StoryMapMenu.tsx
+++ b/src/components/layout/StoryMapMenu.tsx
@@ -46,7 +46,10 @@ export function StoryMapMenu() {
         <Menu.Item
           color="red"
           leftSection={<IconTrash size={14} />}
-          onClick={deleteAllStoryMaps}
+          onClick={() => {
+            deleteAllStoryMaps();
+            navigate(RouteNames.STORY_MAP_VIEW);
+          }}
         >
           Delete All Story Maps
         </Menu.Item>


### PR DESCRIPTION
Fixes the missing navigation upon deleting all story maps:

Before (when clicking "Delete all story maps" while inside a story map):
![image](https://github.com/MaibornWolff/ProjectCanvas/assets/78490564/c0ad30a4-5210-4dfc-bf60-6c7a43ed553a)

After:
![image](https://github.com/MaibornWolff/ProjectCanvas/assets/78490564/6cd514fc-5a9f-4252-9a16-37a7b4536c2b)

* Fixes https://projectcanvas.atlassian.net/browse/SCRUM-102