### PR TITLE
Add title and save/close buttons to the split view

### DIFF
--- a/src/components/BacklogView/Issue/IssueCard.tsx
+++ b/src/components/BacklogView/Issue/IssueCard.tsx
@@ -190,7 +190,10 @@ export function IssueCard({
           labels={labels}
           assignee={assignee}
           projectId={projectId}
-          closeModal={() => setOpened(false)}
+          closeModal={() => {
+            setOpened(false);
+            queryClient.invalidateQueries({ queryKey: ["issues"] });
+          }}
           {...props}
         />
       </Modal>

--- a/src/components/DetailView/Components/Description.tsx
+++ b/src/components/DetailView/Components/Description.tsx
@@ -1,41 +1,25 @@
 import { Textarea, Text } from "@mantine/core";
-import { showNotification } from "@mantine/notifications";
-import { useMutation } from "@tanstack/react-query";
-import { Issue } from "types";
 import { useState } from "react";
-import { editIssue } from "../helpers/queryFunctions";
 
-export function Description(props: { issueKey: string, description: string }) {
-  const [defaultDescription, setDefaultDescription] = useState(
-    props.description,
-  );
+export function Description({
+  description,
+  onChange,
+}: {
+  description: string,
+  onChange: (newDescription: string) => void,
+}) {
+  const [currentDescription, setCurrentDescription] = useState(description);
   const [showDescriptionInput, setShowDescriptionInput] = useState(false);
-  const mutationDescription = useMutation({
-    mutationFn: (issue: Issue) => editIssue(issue, props.issueKey),
-    onError: () => {
-      showNotification({
-        message: "An error occurred while modifing the Description 😢",
-        color: "red",
-      });
-    },
-    onSuccess: () => {
-      showNotification({
-        message: `Description of issue ${props.issueKey} has been modified!`,
-        color: "green",
-      });
-    },
-  });
+
   return (
     <span>
       {showDescriptionInput ? (
         <Textarea
-          value={defaultDescription}
-          onChange={(e) => setDefaultDescription(e.target.value)}
+          value={currentDescription}
+          onChange={(e) => setCurrentDescription(e.target.value)}
           onBlur={() => {
             setShowDescriptionInput(false);
-            mutationDescription.mutate({
-              description: defaultDescription,
-            } as Issue);
+            onChange(currentDescription);
           }}
           autosize
           minRows={4}
@@ -43,9 +27,7 @@ export function Description(props: { issueKey: string, description: string }) {
         />
       ) : (
         <Text onClick={() => setShowDescriptionInput(true)} mb="xl">
-          {defaultDescription !== undefined && defaultDescription !== null && defaultDescription !== ""
-            ? defaultDescription
-            : "Add Description"}
+          {currentDescription || "Add Description"}
         </Text>
       )}
     </span>

--- a/src/components/DetailView/Components/SplitIssue/SplitIssueDetails.tsx
+++ b/src/components/DetailView/Components/SplitIssue/SplitIssueDetails.tsx
@@ -35,9 +35,11 @@ export function SplitIssueDetails(
     sprint,
     attachments,
     onIssueSelected,
+    onIssueDescriptionChanged,
     selectedSplitIssues,
   } : Issue & {
     onIssueSelected: (issueKey: string) => void,
+    onIssueDescriptionChanged: (newDescription: string) => void,
     selectedSplitIssues: string[],
   },
 ) {
@@ -67,7 +69,10 @@ export function SplitIssueDetails(
           <Text c="dimmed" mb="sm">
             Description
           </Text>
-          <Description issueKey={issueKey} description={description} />
+          <Description
+            description={description}
+            onChange={onIssueDescriptionChanged}
+          />
           <Group justify="left" mb="sm">
             <IssueStatusMenu
               projectId={projectId}

--- a/src/components/DetailView/Components/SplitIssue/SplitView.tsx
+++ b/src/components/DetailView/Components/SplitIssue/SplitView.tsx
@@ -1,5 +1,6 @@
-import { Center, Group, Loader, Modal, Paper } from "@mantine/core";
+import { Center, Group, Loader, Modal, Paper, Button, Text } from "@mantine/core";
 import { useQuery } from "@tanstack/react-query";
+import { IconDeviceFloppy, IconX } from "@tabler/icons-react";
 import { Issue } from "../../../../../types";
 import { SplitIssueDetails } from "./SplitIssueDetails";
 import { SplitIssueCreate } from "./SplitIssueCreate";
@@ -67,6 +68,18 @@ export function SplitView({
       withCloseButton={false}
       size="90vw"
     >
+      <Group mb="sm" justify="space-between">
+        <Text>Split-View</Text>
+
+        <Group>
+          <Button c="div" color="primaryBlue">
+            <IconDeviceFloppy />
+          </Button>
+          <Button c="div" variant="transparent" color="red" pl="0">
+            <IconX />
+          </Button>
+        </Group>
+      </Group>
       <Group style={{ alignItems: "stretch" }}>
         {selectedSplitIssues.map((issueKey) => (
           <Paper withBorder style={{ flex: 1 }} key={issueKey}>

--- a/src/components/DetailView/Components/SplitIssue/SplitView.tsx
+++ b/src/components/DetailView/Components/SplitIssue/SplitView.tsx
@@ -132,7 +132,7 @@ export function SplitView({
           >
             <IconDeviceFloppy />
           </Button>
-          <Button c="div" variant="transparent" color="red" pl="0">
+          <Button c="div" variant="transparent" color="red" pl="0" onClick={() => onClose()}>
             <IconX />
           </Button>
         </Group>

--- a/src/components/DetailView/Components/SplitIssue/SplitView.tsx
+++ b/src/components/DetailView/Components/SplitIssue/SplitView.tsx
@@ -62,7 +62,9 @@ export function SplitView({
       });
     },
     onSuccess: () => {
-      const issueKeys = Object.keys(modifiedDescriptions).join(", ");
+      const issueKeys = Object.keys(modifiedDescriptions)
+        .filter((x) => !!modifiedDescriptions[x])
+        .join(", ");
       showNotification({
         message: `Description of the following issues has been modified: ${issueKeys}!`,
         color: "green",

--- a/src/components/DetailView/DetailView.tsx
+++ b/src/components/DetailView/DetailView.tsx
@@ -1,6 +1,8 @@
 import { Accordion, Box, Breadcrumbs, Group, Paper, ScrollArea, Stack, Text, Title } from "@mantine/core";
 import { Issue } from "types";
 import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { showNotification } from "@mantine/notifications";
 import { AddSubtask } from "./Components/AddSubtask";
 import { AssigneeMenu } from "./Components/AssigneeMenu";
 import { EditableEpic } from "./Components/EditableEpic";
@@ -19,6 +21,7 @@ import { IssueIcon } from "../BacklogView/Issue/IssueIcon";
 import { IssueStatusMenu } from "./Components/IssueStatusMenu";
 import { SplitIssueButton } from "./Components/SplitIssue/SplitIssueButton";
 import { SplitView } from "./Components/SplitIssue/SplitView";
+import { editIssue } from "./helpers/queryFunctions";
 
 export function DetailView({
   issueKey,
@@ -47,6 +50,22 @@ export function DetailView({
   const replaceSelectedIssue = (oldIssue: string, newIssue: string) => {
     setSelectedSplitIssues(selectedSplitIssues.with(selectedSplitIssues.indexOf(oldIssue), newIssue));
   };
+
+  const mutationDescription = useMutation({
+    mutationFn: (issue: Partial<Issue>) => editIssue(issue as Issue, issueKey),
+    onError: () => {
+      showNotification({
+        message: "An error occurred while modifing the Description 😢",
+        color: "red",
+      });
+    },
+    onSuccess: () => {
+      showNotification({
+        message: `Description of issue ${issueKey} has been modified!`,
+        color: "green",
+      });
+    },
+  });
 
   return (
     <Paper p="xs">
@@ -79,7 +98,12 @@ export function DetailView({
             <Text c="dimmed" mb="sm">
               Description
             </Text>
-            <Description issueKey={issueKey} description={description} />
+            <Description
+              description={description}
+              onChange={(newDescription) => {
+                mutationDescription.mutate({ description: newDescription });
+              }}
+            />
             <Text c="dimmed" mb="sm">
               Child Issues
             </Text>

--- a/src/components/DetailView/DetailView.tsx
+++ b/src/components/DetailView/DetailView.tsx
@@ -141,6 +141,7 @@ export function DetailView({
                 onClose={() => {
                   setSelectedSplitIssues(() => [issueKey]);
                   setCreateSplitViewOpened(false);
+                  closeModal();
                 }}
                 onCreate={(newIssueKey: string, previousNewIssueIdentifier: string) => {
                   replaceSelectedIssue(previousNewIssueIdentifier, newIssueKey);

--- a/src/components/EpicDetailView/EpicDetailView.tsx
+++ b/src/components/EpicDetailView/EpicDetailView.tsx
@@ -14,8 +14,9 @@ import {
   Tooltip,
 } from "@mantine/core";
 import { Attachment, Issue, User } from "types";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { showNotification } from "@mantine/notifications";
 import { AssigneeMenu } from "../DetailView/Components/AssigneeMenu";
 import { Description } from "../DetailView/Components/Description";
 import { IssueSummary } from "./Components/IssueSummary";
@@ -36,6 +37,7 @@ import { StatusType } from "../../../types/status";
 import { getStatusTypeColor } from "../../common/status-color";
 import { Attachments } from "../DetailView/Components/Attachments/Attachments";
 import { IssueStatusMenu } from "../DetailView/Components/IssueStatusMenu";
+import { editIssue } from "../DetailView/helpers/queryFunctions";
 
 export function EpicDetailView({
   issueKey,
@@ -101,6 +103,22 @@ export function EpicDetailView({
       ?.sort((issueA: Issue, issueB: Issue) => sortIssuesByRank(issueA, issueB)) ?? [],
   });
 
+  const mutationDescription = useMutation({
+    mutationFn: (issue: Partial<Issue>) => editIssue(issue as Issue, issueKey),
+    onError: () => {
+      showNotification({
+        message: "An error occurred while modifing the Description 😢",
+        color: "red",
+      });
+    },
+    onSuccess: () => {
+      showNotification({
+        message: `Description of issue ${issueKey} has been modified!`,
+        color: "green",
+      });
+    },
+  });
+
   const getStatusNamesInCategory = (category: StatusType) => issueStatusByCategory[category]?.map((s) => s.name) ?? [];
   const validTodoStatus = getStatusNamesInCategory(StatusType.TODO);
   const validInProgressStatus = getStatusNamesInCategory(
@@ -163,7 +181,12 @@ export function EpicDetailView({
               marginTop: "-7px",
             }}
           >
-            <Description issueKey={issueKey} description={description} />
+            <Description
+              description={description}
+              onChange={(newDescription) => {
+                mutationDescription.mutate({ description: newDescription });
+              }}
+            />
           </Group>
           <Group align="center" p="sm">
             <Progress.Root


### PR DESCRIPTION
Adds a title and a save and close button to the split view modal:

![image](https://github.com/MaibornWolff/ProjectCanvas/assets/78490564/64037032-a219-44d2-917f-ad1abd9c8a4d)

Additionally causes the detail view to close when closing the split view.

* Closes https://projectcanvas.atlassian.net/browse/SCRUM-126
* Closes https://projectcanvas.atlassian.net/browse/SCRUM-129
* Closes https://projectcanvas.atlassian.net/browse/SCRUM-124