### PR TITLE
Fix loading states of backlog, epics list and projects list

### DIFF
--- a/src/components/BacklogView/BacklogView.tsx
+++ b/src/components/BacklogView/BacklogView.tsx
@@ -1,17 +1,4 @@
-import {
-  Box,
-  Button,
-  Center,
-  Divider,
-  Flex,
-  Group,
-  Loader,
-  ScrollArea,
-  Stack,
-  Text,
-  TextInput,
-  Title,
-} from "@mantine/core";
+import { Box, Button, Center, Divider, Flex, Group, ScrollArea, Stack, Text, TextInput, Title } from "@mantine/core";
 import { IconSearch } from "@tabler/icons-react";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { ChangeEvent, useEffect, useMemo, useState } from "react";
@@ -32,6 +19,7 @@ import { SprintsPanel } from "./IssuesWrapper/SprintsPanel";
 import { ReloadButton } from "./ReloadButton";
 import { useColorScheme } from "../../common/color-scheme";
 import { RouteNames } from "../../route-names";
+import { ProjectDependingView } from "../common/ProjectDependingView/ProjectDependingView";
 
 export function BacklogView() {
   const colorScheme = useColorScheme();
@@ -151,24 +139,10 @@ export function BacklogView() {
   }
 
   return (
-    <Stack style={{ height: "100%" }}>
-      <Stack align="left" gap={0}>
+    <ProjectDependingView
+      title="Backlog"
+      rightHeader={(
         <Group>
-          <Group gap="xs" c="dimmed">
-            <Text
-              onClick={() => navigate(RouteNames.PROJECTS_VIEW)}
-              style={{
-                ":hover": {
-                  textDecoration: "underline",
-                  cursor: "pointer",
-                },
-              }}
-            >
-              Projects
-            </Text>
-            <Text>/</Text>
-            <Text>{selectedProject?.name}</Text>
-          </Group>
           <Button
             ml="auto"
             size="xs"
@@ -176,21 +150,10 @@ export function BacklogView() {
           >
             Export
           </Button>
-          <CreateExportModal
-            opened={createExportModalOpened}
-            setOpened={setCreateExportModalOpened}
-          />
           <ReloadButton mr="xs" />
         </Group>
-        <Group mb="sm" gap="0">
-          <Title mr="sm">Backlog</Title>
-          {isFetchingSprints || issueQueries.some((query) => query.isFetching) ? (
-            <>
-              <Loader size="sm" />
-              <Text ml="sm">Fetching...</Text>
-            </>
-          ) : undefined}
-        </Group>
+      )}
+      searchBar={(
         <TextInput
           placeholder="Search by issue summary, key, epic, labels, creator or assignee.."
           leftSection={<IconSearch size={14} stroke={1.5} />}
@@ -199,7 +162,13 @@ export function BacklogView() {
             setSearch(event.currentTarget.value);
           }}
         />
-      </Stack>
+      )}
+      isLoadingContent={isFetchingSprints || issueQueries.some((query) => query.isFetching)}
+    >
+      <CreateExportModal
+        opened={createExportModalOpened}
+        setOpened={setCreateExportModalOpened}
+      />
 
       <Flex style={{ flexGrow: 1 }}>
         <DragDropContext
@@ -287,6 +256,6 @@ export function BacklogView() {
           </ScrollArea.Autosize>
         </DragDropContext>
       </Flex>
-    </Stack>
+    </ProjectDependingView>
   );
 }

--- a/src/components/BacklogView/BacklogView.tsx
+++ b/src/components/BacklogView/BacklogView.tsx
@@ -1,9 +1,8 @@
-import { Box, Button, Center, Divider, Flex, Group, ScrollArea, Stack, Text, TextInput, Title } from "@mantine/core";
+import { Box, Button, Center, Divider, Flex, Group, ScrollArea, Text, TextInput } from "@mantine/core";
 import { IconSearch } from "@tabler/icons-react";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { ChangeEvent, useEffect, useMemo, useState } from "react";
 import { DragDropContext } from "@hello-pangea/dnd";
-import { useNavigate } from "react-router-dom";
 import { Issue, Sprint } from "types";
 import { UseQueryOptions } from "@tanstack/react-query/src/types";
 import { useCanvasStore } from "../../lib/Store";
@@ -18,12 +17,10 @@ import { DraggableIssuesWrapper } from "./IssuesWrapper/DraggableIssuesWrapper";
 import { SprintsPanel } from "./IssuesWrapper/SprintsPanel";
 import { ReloadButton } from "./ReloadButton";
 import { useColorScheme } from "../../common/color-scheme";
-import { RouteNames } from "../../route-names";
 import { ProjectDependingView } from "../common/ProjectDependingView/ProjectDependingView";
 
 export function BacklogView() {
   const colorScheme = useColorScheme();
-  const navigate = useNavigate();
 
   resizeDivider();
 
@@ -115,20 +112,6 @@ export function BacklogView() {
     ),
     [issuesWrapper, search],
   );
-
-  if (!selectedProject) {
-    return (
-      <Center style={{ width: "100%", height: "100%" }}>
-        <Stack align="center">
-          <Title>No Project has been selected!</Title>
-          <Text>Please go back to the project selection and select a project</Text>
-          <Button onClick={() => navigate(RouteNames.PROJECTS_VIEW)}>
-            To the project selection
-          </Button>
-        </Stack>
-      </Center>
-    );
-  }
 
   if (isErrorSprints || issueQueries.some((query) => query.isError)) {
     return (

--- a/src/components/BacklogView/BacklogView.tsx
+++ b/src/components/BacklogView/BacklogView.tsx
@@ -16,12 +16,9 @@ import { resizeDivider } from "./helpers/resizeDivider";
 import { DraggableIssuesWrapper } from "./IssuesWrapper/DraggableIssuesWrapper";
 import { SprintsPanel } from "./IssuesWrapper/SprintsPanel";
 import { ReloadButton } from "./ReloadButton";
-import { useColorScheme } from "../../common/color-scheme";
 import { ProjectDependingView } from "../common/ProjectDependingView/ProjectDependingView";
 
 export function BacklogView() {
-  const colorScheme = useColorScheme();
-
   resizeDivider();
 
   const { selectedProject, selectedProjectBoardIds: boardIds } = useCanvasStore();
@@ -148,10 +145,8 @@ export function BacklogView() {
       )}
       isLoadingContent={isFetchingSprints || issueQueries.some((query) => query.isFetching)}
     >
-      <CreateExportModal
-        opened={createExportModalOpened}
-        setOpened={setCreateExportModalOpened}
-      />
+      <CreateExportModal opened={createExportModalOpened} setOpened={setCreateExportModalOpened} />
+      <CreateIssueModal opened={createIssueModalOpened} setOpened={setCreateIssueModalOpened} />
 
       <Flex style={{ flexGrow: 1 }}>
         <DragDropContext
@@ -181,39 +176,23 @@ export function BacklogView() {
             <Box mr="xs">
               <Button
                 mt="sm"
-                mb="xl"
                 variant="subtle"
                 color="gray"
-                radius="sm"
                 display="flex"
+                justify="left"
                 fullWidth
                 onClick={() => setCreateIssueModalOpened(true)}
-                style={(theme) => ({
-                  justifyContent: "left",
-                  ":hover": {
-                    background:
-                      colorScheme === "dark"
-                        ? theme.colors.dark[4]
-                        : theme.colors.gray[4],
-                  },
-                })}
               >
                 + Create Issue
               </Button>
             </Box>
-            <CreateIssueModal
-              opened={createIssueModalOpened}
-              setOpened={setCreateIssueModalOpened}
-            />
           </ScrollArea.Autosize>
           <Divider
             mr="xs"
             size="xl"
             className="resize-handle"
             orientation="vertical"
-            style={{
-              cursor: "col-resize",
-            }}
+            style={{ cursor: "col-resize" }}
           />
           <ScrollArea.Autosize
             className="right-panel"

--- a/src/components/BacklogView/ReloadButton.tsx
+++ b/src/components/BacklogView/ReloadButton.tsx
@@ -7,7 +7,7 @@ export function ReloadButton({ ...props }) {
   return (
     <ActionIcon
       variant="default"
-      onClick={() => queryClient.invalidateQueries({ queryKey: ["issues", "sprints"] })}
+      onClick={() => queryClient.invalidateQueries({ queryKey: ["issues"] })}
       size={30}
       {...props}
     >

--- a/src/components/EpicView/EpicView.tsx
+++ b/src/components/EpicView/EpicView.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack, Text, Title, ScrollArea, Box, Button, Center, Loader, TextInput } from "@mantine/core";
+import { Stack, Text, Title, ScrollArea, Box, Button, Center, TextInput } from "@mantine/core";
 import { useNavigate } from "react-router-dom";
 import { ChangeEvent, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -10,64 +10,45 @@ import { getEpics } from "./helpers/queryFetchers";
 import { useColorScheme } from "../../common/color-scheme";
 import { RouteNames } from "../../route-names";
 import { filterSearch } from "./helpers/epicViewHelpers";
+import { ProjectDependingView } from "../common/ProjectDependingView/ProjectDependingView";
 
 export function EpicView() {
   const colorScheme = useColorScheme();
   const navigate = useNavigate();
-  const projectName = useCanvasStore((state) => state.selectedProject?.name);
+
+  const { selectedProject } = useCanvasStore();
+  const projectKey = selectedProject?.key;
+
   const [createIssueModalOpened, setCreateIssueModalOpened] = useState(false);
-  const projectKey = useCanvasStore((state) => state.selectedProject?.key);
   const [search, setSearch] = useState("");
 
-  const { isLoading: isLoadingEpics, data: epics } = useQuery({
+  const { isFetching, data: epics } = useQuery({
     queryKey: ["epics", projectKey],
     queryFn: () => getEpics(projectKey),
     enabled: !!projectKey,
     initialData: [],
   });
 
-  const searchedEpics = filterSearch(search, epics);
-
-  if (isLoadingEpics) {
+  if (!selectedProject) {
     return (
       <Center style={{ width: "100%", height: "100%" }}>
-        {projectKey ? (
-          <Loader />
-        ) : (
-          <Stack align="center">
-            <Title>No Project has been selected!</Title>
-            <Text>
-              Please go back to the Projects View section and select a project
-            </Text>
-            <Button onClick={() => navigate(RouteNames.PROJECTS_VIEW)}>
-              Go back
-            </Button>
-          </Stack>
-        )}
+        <Stack align="center">
+          <Title>No Project has been selected!</Title>
+          <Text>Please go back to the project selection and select a project</Text>
+          <Button onClick={() => navigate(RouteNames.PROJECTS_VIEW)}>
+            To the project selection
+          </Button>
+        </Stack>
       </Center>
     );
   }
+
+  const searchedEpics = filterSearch(search, epics);
+
   return (
-    <Stack style={{ minHeight: "100%" }}>
-      <Stack align="left" gap={0}>
-        <Group>
-          <Group gap="xs" c="dimmed">
-            <Text
-              onClick={() => navigate(RouteNames.PROJECTS_VIEW)}
-              style={{
-                ":hover": {
-                  textDecoration: "underline",
-                  cursor: "pointer",
-                },
-              }}
-            >
-              Projects
-            </Text>
-            <Text>/</Text>
-            <Text>{projectName}</Text>
-          </Group>
-        </Group>
-        <Title mb="sm">Epics</Title>
+    <ProjectDependingView
+      title="Epics"
+      searchBar={(
         <TextInput
           placeholder="Search by summary, id, creator, labels, status or assignee..."
           leftSection={<IconSearch size={14} stroke={1.5} />}
@@ -76,7 +57,9 @@ export function EpicView() {
             setSearch(event.currentTarget.value);
           }}
         />
-      </Stack>
+      )}
+      isLoadingContent={isFetching}
+    >
       <ScrollArea.Autosize
         className="main-panel"
         w="100%"
@@ -117,6 +100,6 @@ export function EpicView() {
           setOpened={setCreateIssueModalOpened}
         />
       </ScrollArea.Autosize>
-    </Stack>
+    </ProjectDependingView>
   );
 }

--- a/src/components/EpicView/EpicView.tsx
+++ b/src/components/EpicView/EpicView.tsx
@@ -1,5 +1,4 @@
-import { Stack, Text, Title, ScrollArea, Box, Button, Center, TextInput } from "@mantine/core";
-import { useNavigate } from "react-router-dom";
+import { ScrollArea, Box, Button, TextInput } from "@mantine/core";
 import { ChangeEvent, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { IconSearch } from "@tabler/icons-react";
@@ -8,13 +7,11 @@ import { CreateIssueModal } from "../CreateIssue/CreateIssueModal";
 import { EpicWrapper } from "./EpicWrapper";
 import { getEpics } from "./helpers/queryFetchers";
 import { useColorScheme } from "../../common/color-scheme";
-import { RouteNames } from "../../route-names";
 import { filterSearch } from "./helpers/epicViewHelpers";
 import { ProjectDependingView } from "../common/ProjectDependingView/ProjectDependingView";
 
 export function EpicView() {
   const colorScheme = useColorScheme();
-  const navigate = useNavigate();
 
   const { selectedProject } = useCanvasStore();
   const projectKey = selectedProject?.key;
@@ -28,21 +25,6 @@ export function EpicView() {
     enabled: !!projectKey,
     initialData: [],
   });
-
-  if (!selectedProject) {
-    return (
-      <Center style={{ width: "100%", height: "100%" }}>
-        <Stack align="center">
-          <Title>No Project has been selected!</Title>
-          <Text>Please go back to the project selection and select a project</Text>
-          <Button onClick={() => navigate(RouteNames.PROJECTS_VIEW)}>
-            To the project selection
-          </Button>
-        </Stack>
-      </Center>
-    );
-  }
-
   const searchedEpics = filterSearch(search, epics);
 
   return (

--- a/src/components/ProjectsView/ProjectsView.tsx
+++ b/src/components/ProjectsView/ProjectsView.tsx
@@ -2,32 +2,24 @@ import { Center, Loader, Text } from "@mantine/core";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useCanvasStore } from "../../lib/Store";
-import { getProjects } from "./queryFetchers";
 import { ProjectsTable } from "./Table/ProjectsTable";
 
 export function ProjectsView() {
   const { setProjects } = useCanvasStore();
-  const { data: projects, isLoading } = useQuery({
+  const { data: projects } = useQuery({
     queryKey: ["projects"],
-    queryFn: getProjects,
-    initialData: [],
+    queryFn: async () => window.provider.getProjects(),
   });
 
-  useEffect(() => setProjects(projects), [projects]);
+  useEffect(() => setProjects(projects ?? []), [projects]);
 
-  if (isLoading) {
-    return (
-      <Center style={{ width: "100%", height: "100%" }}>
-        <Loader />
-      </Center>
-    );
+  if (!projects) {
+    return (<Center style={{ width: "100%", height: "100%" }}><Loader /></Center>);
   }
 
-  if (projects.length > 0) return <ProjectsTable data={projects} />;
+  if (projects.length === 0) {
+    return (<Center style={{ width: "100%", height: "100%" }}><Text>No Projects Found</Text></Center>);
+  }
 
-  return (
-    <Center style={{ width: "100%", height: "100%" }}>
-      <Text>No Projects Found</Text>
-    </Center>
-  );
+  return <ProjectsTable data={projects} />;
 }

--- a/src/components/ProjectsView/Table/ProjectsTable.tsx
+++ b/src/components/ProjectsView/Table/ProjectsTable.tsx
@@ -42,16 +42,19 @@ export function ProjectsTable({ data }: { data: Project[] }) {
 
   const onClickRow = async (row: Project) => {
     setSelectedProject(row);
-    setSelectedProjectBoardIds(await window.provider.getBoardIds(row.key));
-    setIssueTypes(await window.provider.getIssueTypesByProject(row.key));
-    setIssueTypesWithFieldsMap(
-      await window.provider.getIssueTypesWithFieldsMap()
+    const [boardIds, issueTypes, issueTypesWithFieldsMap] = await Promise.all([
+      window.provider.getBoardIds(row.key),
+      window.provider.getIssueTypesByProject(row.key),
+      window.provider.getIssueTypesWithFieldsMap()
         .then(async (mapResponse) => {
           const map = new Map<string, string[]>();
           Object.entries(mapResponse).forEach(([key, value]) => map.set(key, value));
           return map;
         }),
-    );
+    ]);
+    setSelectedProjectBoardIds(boardIds);
+    setIssueTypes(issueTypes);
+    setIssueTypesWithFieldsMap(issueTypesWithFieldsMap);
     navigate(RouteNames.BACKLOG_VIEW);
   };
 

--- a/src/components/ProjectsView/queryFetchers.ts
+++ b/src/components/ProjectsView/queryFetchers.ts
@@ -1,4 +1,0 @@
-import { ipcRenderer } from "electron";
-import { Project } from "types";
-
-export const getProjects = (): Promise<Project[]> => ipcRenderer.invoke("getProjects");

--- a/src/components/common/ProjectDependingView/ProjectDependingView.tsx
+++ b/src/components/common/ProjectDependingView/ProjectDependingView.tsx
@@ -1,4 +1,4 @@
-import { Box, Group, Loader, Stack, Text, Title } from "@mantine/core";
+import { Box, Group, Loader, Stack, Text, Title, Button, Center } from "@mantine/core";
 import { ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { useCanvasStore } from "../../../lib/Store";
@@ -19,6 +19,20 @@ export function ProjectDependingView({
 }) {
   const navigate = useNavigate();
   const { selectedProject } = useCanvasStore();
+
+  if (!selectedProject) {
+    return (
+      <Center style={{ width: "100%", height: "100%" }}>
+        <Stack align="center">
+          <Title>No Project has been selected!</Title>
+          <Text>Please go back to the project selection and select a project</Text>
+          <Button onClick={() => navigate(RouteNames.PROJECTS_VIEW)}>
+            To the project selection
+          </Button>
+        </Stack>
+      </Center>
+    );
+  }
 
   return (
     <Stack style={{ height: "100%" }}>

--- a/src/components/common/ProjectDependingView/ProjectDependingView.tsx
+++ b/src/components/common/ProjectDependingView/ProjectDependingView.tsx
@@ -1,0 +1,61 @@
+import { Box, Group, Loader, Stack, Text, Title } from "@mantine/core";
+import { ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCanvasStore } from "../../../lib/Store";
+import { RouteNames } from "../../../route-names";
+
+export function ProjectDependingView({
+  title,
+  children,
+  rightHeader,
+  searchBar,
+  isLoadingContent,
+}: {
+  title: string,
+  children: ReactNode,
+  rightHeader?: ReactNode,
+  searchBar?: ReactNode,
+  isLoadingContent?: boolean,
+}) {
+  const navigate = useNavigate();
+  const { selectedProject } = useCanvasStore();
+
+  return (
+    <Stack style={{ height: "100%" }}>
+      <Stack align="left" gap={0}>
+        <Group>
+          <Group gap="xs" c="dimmed">
+            <Text
+              onClick={() => navigate(RouteNames.PROJECTS_VIEW)}
+              style={{
+                ":hover": {
+                  textDecoration: "underline",
+                  cursor: "pointer",
+                },
+              }}
+            >
+              Projects
+            </Text>
+            <Text>/</Text>
+            <Text>{selectedProject?.name}</Text>
+          </Group>
+          <Box ml="auto">
+            {rightHeader}
+          </Box>
+        </Group>
+        <Group mb="sm" gap="0">
+          <Title mr="sm">{title}</Title>
+          {isLoadingContent ? (
+            <>
+              <Loader size="sm" />
+              <Text ml="sm">Fetching...</Text>
+            </>
+          ) : undefined}
+        </Group>
+        {searchBar}
+      </Stack>
+
+      {children}
+    </Stack>
+  );
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -22,7 +22,7 @@ export function Layout() {
       <AppShell.Header>
         <LayoutHeader />
       </AppShell.Header>
-      <AppShell.Main>
+      <AppShell.Main h="100vh">
         <Outlet />
       </AppShell.Main>
     </AppShell>


### PR DESCRIPTION
Fixes the styling and loading refresh states of the backlog, the epics list and the projects list.

When (re)fetching, a loader will be shown next to the title instead of the whole view / list being toggled:
![image](https://github.com/MaibornWolff/ProjectCanvas/assets/78490564/b315a99d-0886-4d98-8a12-d0f5be999a6f)

Now correctly requires that a project is set in the backlog and the epics list.
Also refactors and unifies the project depending view handling in both the backlog and the epics view.

* Fixes https://projectcanvas.atlassian.net/browse/SCRUM-119